### PR TITLE
fix: raise http error when request fails

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 21.10b0
     hooks:
       - id: black
         name: black
@@ -26,7 +26,7 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v0.910-1
     hooks:
     -   id: mypy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
  [build-system]
 requires = ["setuptools>=51.1.1", "wheel", "setuptools_scm[toml]>=5.0"]
 
+[tool.mypy]
+exclude = "build/"
+
 [tool.setuptools_scm]
 write_to = "tokenlists/version.py"
 
@@ -11,28 +14,13 @@ write_to = "tokenlists/version.py"
 
 [tool.black]
 line-length = 100
-target-version = ['py37', 'py38']
+target-version = ['py37', 'py38', 'py39']
 include = '\.pyi?$'
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-  | env
-  | venv
-)/
-'''
 
 [tool.pytest.ini_options]
 addopts = """
     -n auto
+    -p no:ape_test
 	--cov-branch
 	--cov-report term
 	--cov-report html

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require = {
         "hypothesis-jsonschema==0.19.0",  # Fuzzes based on a json schema
     ],
     "lint": [
-        "black>=21.7b0,<22.0",  # auto-formatter and linter
+        "black>=21.10b0,<22.0",  # auto-formatter and linter
         "mypy>=0.910,<1.0",  # Static type analyzer
         "flake8>=3.9.2,<4.0",  # Style linter
         "isort>=5.9.3,<6.0",  # Import sorting linter

--- a/tokenlists/manager.py
+++ b/tokenlists/manager.py
@@ -36,7 +36,9 @@ class TokenListManager:
             uri = config.UNISWAP_ENS_TOKENLISTS_HOST.format(uri)
 
         # Load and store the tokenlist
-        tokenlist = TokenList.parse_obj(requests.get(uri).json())
+        response = requests.get(uri)
+        response.raise_for_status()
+        tokenlist = TokenList.parse_obj(response.json())
         self.installed_tokenlists[tokenlist.name] = tokenlist
 
         # Cache it on disk for later instances


### PR DESCRIPTION
### What I did

First, I tried to do `ape tokens install tokens.link.eth` but it fails with some strange JSON error:

```
requests.exceptions.JSONDecodeError: [Errno Expecting value] error code: 1001: 0
```

I then realized the request was failing but we were not raising an HTTP error. Now, with these new changes, you get this error:

```
requests.exceptions.HTTPError: 409 Client Error: Conflict for url: https://wispy-bird-88a7.uniswap.workers.dev/?url=http://tokens.link.eth.link
```

^ Which is more helpful

### How I did it

Get the response first and call `response.raise_for_status()` and then after that, continue on using its JSON in the decoder (provided it does not raise).

### How to verify it

Try `ape tokens install tokens.link.eth` - It should fail with a 409 error.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
