### PR TITLE
test: fix fuzzing by cleaning out `tokenMap` fields from schema

### DIFF
--- a/tests/functional/test_schema_fuzzing.py
+++ b/tests/functional/test_schema_fuzzing.py
@@ -1,5 +1,5 @@
 import pytest
-import requests
+import requests  # type: ignore[import]
 from hypothesis import HealthCheck, given, settings
 from hypothesis_jsonschema import from_schema
 from pydantic import ValidationError
@@ -9,13 +9,16 @@ from tokenlists import TokenList
 TOKENLISTS_SCHEMA = "https://uniswap.org/tokenlist.schema.json"
 
 
-def clean_iso_timestamps(tl: dict) -> dict:
-    """
-    Timestamps can be in any format, and our processing handles it okay
-    However, for testing purposes, we want the output format to line up,
-    and unfortunately there is some ambiguity in ISO timestamp formats.
-    """
+def clean_data(tl: dict) -> dict:
+    # NOTE: Timestamps can be in any format, and our processing handles it okay
+    #       However, for testing purposes, we want the output format to line up,
+    #       and unfortunately there is some ambiguity in ISO timestamp formats.
     tl["timestamp"] = tl["timestamp"].replace("Z", "+00:00")
+
+    # NOTE: We do not implement `tokenMap` schema version yet
+    if "tokenMap" in tl:
+        del tl["tokenMap"]
+
     return tl
 
 
@@ -24,7 +27,7 @@ def clean_iso_timestamps(tl: dict) -> dict:
 @settings(suppress_health_check=(HealthCheck.too_slow,))
 def test_schema(token_list):
     try:
-        assert TokenList.parse_obj(token_list).dict() == clean_iso_timestamps(token_list)
+        assert TokenList.parse_obj(token_list).dict() == clean_data(token_list)
 
     except (ValidationError, ValueError):
         pass  # Expect these kinds of errors


### PR DESCRIPTION
### What I did

fixes the test failure on `main`

### How I did it

The tokenlist schema added a breaking change to it, so we are avoiding upgrading to that for now