### PR TITLE
refactor!: enhance library DevEx

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,13 +24,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - uses: astral-sh/setup-uv@v6
+    - uses: astral-sh/setup-uv@v7
 
     - name: Install Dependencies
-      run: |
-        uv venv
-        source .venv/bin/activate
-        uv pip install . --group docs
+      run: uv sync
+
+    - name: Add venv to PATH
+      run: echo "${{ github.workspace }}/.venv/bin" >> $GITHUB_PATH
+      # NOTE: Otherwise the next action nukes the path when it starts
 
     - name: Ape Docs
       uses: apeworx/sphinx-ape@main

--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ python3 setup.py install
 ['1inch']
 ```
 
+Token lookup order is controlled locally through `pyproject.toml`:
+
+```toml
+[tool.tokenlists]
+order = ["My Preferred List", "Fallback List"]
+```
+
 ## License
 
 This project is licensed under the [MIT license](LICENSE).

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Token lookup order is controlled locally through `pyproject.toml`:
 order = ["My Preferred List", "Fallback List"]
 ```
 
+HTTP downloads use `httpx` and honor the standard environment variables that HTTPX documents for restricted networks and custom trust stores, including `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`, `SSL_CERT_FILE`, and `SSL_CERT_DIR`.
+
 ## License
 
 This project is licensed under the [MIT license](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,9 @@ keywords = ["ethereum"]
 requires-python = ">=3.10"
 dependencies = [
     "click>=8.1.7,<9",
+    "httpx>=0.27,<1",
     "pydantic>=2.5.2,<3",
     "pyyaml>=6.0,<7",
-    "requests>=2.28.1,<3",
     "tomli>=2.0; python_version<'3.11'",
 ]
 
@@ -51,7 +51,6 @@ test = [
 lint = [
     "ruff",
     "mypy>=1.16,<2",
-    "types-requests",
     "types-setuptools",
     "mdformat>=0.7.19",
     "mdformat-gfm>=0.3.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 ]
 
 [project.entry-points.console_scripts]
-tokenlists = "tokenlists._cli:cli"
+tokenlists = "tokenlists.__main__:cli"
 
 [dependency-groups]
 test = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ dev = [
 packages = ["tokenlists"]
 include-package-data = true
 
+[tool.setuptools.package-data]
+tokenlists = ["suggested.json"]
+
 [tool.setuptools_scm]
 write_to = "tokenlists/version.py"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pydantic>=2.5.2,<3",
     "pyyaml>=6.0,<7",
     "requests>=2.28.1,<3",
+    "tomli>=2.0; python_version<'3.11'",
 ]
 
 [project.entry-points.console_scripts]

--- a/tests/functional/test_schema_fuzzing.py
+++ b/tests/functional/test_schema_fuzzing.py
@@ -1,5 +1,5 @@
+import httpx
 import pytest
-import requests
 from hypothesis import HealthCheck, given, settings
 from hypothesis_jsonschema import from_schema
 from pydantic import ValidationError
@@ -7,6 +7,7 @@ from pydantic import ValidationError
 from tokenlists import TokenList
 
 TOKENLISTS_SCHEMA = "https://uniswap.org/tokenlist.schema.json"
+TOKENLISTS_SCHEMA_JSON = httpx.get(TOKENLISTS_SCHEMA, follow_redirects=True).json()
 
 
 def clean_data(tl: dict) -> dict:
@@ -23,7 +24,7 @@ def clean_data(tl: dict) -> dict:
 
 
 @pytest.mark.fuzzing
-@given(token_list=from_schema(requests.get(TOKENLISTS_SCHEMA).json()))
+@given(token_list=from_schema(TOKENLISTS_SCHEMA_JSON))
 @settings(suppress_health_check=(HealthCheck.too_slow,))
 def test_schema(token_list):
     try:

--- a/tests/functional/test_uniswap_examples.py
+++ b/tests/functional/test_uniswap_examples.py
@@ -2,8 +2,8 @@ import os
 from typing import Any
 
 import github
+import httpx
 import pytest
-import requests
 from pydantic import ValidationError
 
 from tokenlists import TokenList
@@ -25,7 +25,7 @@ UNISWAP_RAW_URL = "https://raw.githubusercontent.com/Uniswap/token-lists/master/
     ],
 )
 def test_uniswap_tokenlists(token_list_name):
-    token_list = requests.get(UNISWAP_RAW_URL + token_list_name).json()
+    token_list = httpx.get(UNISWAP_RAW_URL + token_list_name, follow_redirects=True).json()
 
     if token_list_name == "example.tokenlist.json":
         # NOTE: No idea why this breaking change was necessary

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,8 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 
-from tokenlists import _cli, config
+from tokenlists import config
+from tokenlists.__main__ import cli as tokenlists_cli
 
 
 @pytest.fixture
@@ -17,4 +18,4 @@ def runner(monkeypatch):
 @pytest.fixture
 def cli(runner):
     # NOTE: Depends on `runner` fixture for config side effects
-    yield _cli.cli
+    yield tokenlists_cli

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -76,3 +76,38 @@ def test_token_info_displays_tokenlist_name(runner, cli, monkeypatch):
     result = runner.invoke(cli, ["token-info", "TKN"])
     assert result.exit_code == 0
     assert "Token List: Preferred List" in result.output
+
+
+def test_update_warns_when_source_url_missing(runner, cli, monkeypatch):
+    class FakeManager:
+        def available_tokenlists(self):
+            return ["Preferred List"]
+
+        def update_tokenlist(self, tokenlist_name):
+            return None
+
+    monkeypatch.setattr(cli_module, "TokenListManager", FakeManager)
+
+    result = runner.invoke(cli, ["update", "Preferred List"])
+    assert result.exit_code == 0
+    assert "does not have a stored source URL and cannot be updated" in result.output
+
+
+def test_update_all_updates_each_list(runner, cli, monkeypatch):
+    updated = []
+
+    class FakeManager:
+        def available_tokenlists(self):
+            return ["Alpha", "Beta"]
+
+        def update_tokenlist(self, tokenlist_name):
+            updated.append(tokenlist_name)
+            return tokenlist_name
+
+    monkeypatch.setattr(cli_module, "TokenListManager", FakeManager)
+
+    result = runner.invoke(cli, ["update", "--all"])
+    assert result.exit_code == 0
+    assert updated == ["Alpha", "Beta"]
+    assert "Updated 'Alpha'." in result.output
+    assert "Updated 'Beta'." in result.output

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -14,6 +14,15 @@ def test_empty_list(runner, cli):
     result = runner.invoke(cli, ["list"])
     assert result.exit_code == 0
     assert "No tokenlists exist" in result.output
+    assert "tokenlists suggestions" in result.output
+
+
+def test_suggestions(runner, cli):
+    result = runner.invoke(cli, ["suggestions"])
+    assert result.exit_code == 0
+    assert "Suggested Token Lists:" in result.output
+    assert "Uniswap Default List" in result.output
+    assert "https://ipfs.io/ipns/tokens.uniswap.org" in result.output
 
 
 def test_install(runner, cli):

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -45,11 +45,7 @@ def test_remove(runner, cli):
     assert "No tokenlists exist" in result.output
 
 
-def test_default(runner, cli):
-    result = runner.invoke(cli, ["install", TEST_URI])
-    assert result.exit_code == 0
-
+def test_set_default_removed(runner, cli):
     result = runner.invoke(cli, ["set-default", "1inch default token list"])
-
-    assert result.exit_code == 0
-    assert "1inch" in result.output
+    assert result.exit_code != 0
+    assert "No such command 'set-default'" in result.output

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -1,3 +1,4 @@
+from tokenlists import __main__ as cli_module
 from tokenlists.version import version
 
 TEST_URI = "tokens.1inch.eth"
@@ -49,3 +50,29 @@ def test_set_default_removed(runner, cli):
     result = runner.invoke(cli, ["set-default", "1inch default token list"])
     assert result.exit_code != 0
     assert "No such command 'set-default'" in result.output
+
+
+def test_token_info_displays_tokenlist_name(runner, cli, monkeypatch):
+    class FakeTokenInfo:
+        def model_dump(self, mode="json"):
+            return {
+                "symbol": "TKN",
+                "name": "Token",
+                "chainId": 137,
+                "address": "0x0000000000000000000000000000000000000001",
+                "decimals": 18,
+                "tags": [],
+            }
+
+    class FakeManager:
+        def available_tokenlists(self):
+            return ["Preferred List"]
+
+        def get_token_info_with_tokenlist(self, symbol, tokenlist_name, chain_id, case_insensitive):
+            return "Preferred List", FakeTokenInfo()
+
+    monkeypatch.setattr(cli_module, "TokenListManager", FakeManager)
+
+    result = runner.invoke(cli, ["token-info", "TKN"])
+    assert result.exit_code == 0
+    assert "Token List: Preferred List" in result.output

--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -97,7 +97,92 @@ def test_legacy_default_file_warns_and_migrates_order(tmp_path, monkeypatch):
     assert manager.get_token_info("TKN").address == "0x0000000000000000000000000000000000000002"
 
 
-def _write_tokenlist(cache_path, name, *tokens):
+def test_install_persists_resolved_source_url(tmp_path, monkeypatch):
+    cache_path = tmp_path.joinpath("cache")
+    cache_path.mkdir()
+    monkeypatch.setattr(config, "DEFAULT_CACHE_PATH", cache_path)
+    monkeypatch.chdir(tmp_path)
+
+    class FakeResponse:
+        text = ""
+        url = "https://example.com/tokenlist.json"
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {
+                "name": "Alpha",
+                "timestamp": "2024-01-01T00:00:00Z",
+                "version": {"major": 1, "minor": 0, "patch": 0},
+                "tokens": [_token("AAA", "0x0000000000000000000000000000000000000001")],
+            }
+
+    monkeypatch.setattr("tokenlists.manager.requests.get", lambda uri: FakeResponse())
+
+    TokenListManager().install_tokenlist("https://example.com/install.json")
+
+    cached = json.loads(cache_path.joinpath("Alpha.json").read_text())
+    assert cached["tokenlistsSourceUrl"] == "https://example.com/tokenlist.json"
+
+
+def test_update_tokenlist_uses_stored_source_url(tmp_path, monkeypatch):
+    cache_path = tmp_path.joinpath("cache")
+    cache_path.mkdir()
+    monkeypatch.setattr(config, "DEFAULT_CACHE_PATH", cache_path)
+    monkeypatch.chdir(tmp_path)
+
+    _write_tokenlist(
+        cache_path,
+        "Alpha",
+        _token("AAA", "0x0000000000000000000000000000000000000001"),
+        tokenlistsSourceUrl="https://example.com/tokenlist.json",
+    )
+
+    class FakeResponse:
+        text = ""
+        url = "https://cdn.example.com/tokenlist.json"
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {
+                "name": "Alpha",
+                "timestamp": "2024-01-02T00:00:00Z",
+                "version": {"major": 1, "minor": 1, "patch": 0},
+                "tokens": [_token("BBB", "0x0000000000000000000000000000000000000002")],
+            }
+
+    called_uris = []
+
+    def fake_get(uri):
+        called_uris.append(uri)
+        return FakeResponse()
+
+    monkeypatch.setattr("tokenlists.manager.requests.get", fake_get)
+
+    updated_name = TokenListManager().update_tokenlist("Alpha")
+
+    assert updated_name == "Alpha"
+    assert called_uris == ["https://example.com/tokenlist.json"]
+    cached = json.loads(cache_path.joinpath("Alpha.json").read_text())
+    assert cached["version"] == {"major": 1, "minor": 1, "patch": 0}
+    assert cached["tokenlistsSourceUrl"] == "https://cdn.example.com/tokenlist.json"
+
+
+def test_update_tokenlist_without_stored_source_url_returns_none(tmp_path, monkeypatch):
+    cache_path = tmp_path.joinpath("cache")
+    cache_path.mkdir()
+    monkeypatch.setattr(config, "DEFAULT_CACHE_PATH", cache_path)
+    monkeypatch.chdir(tmp_path)
+
+    _write_tokenlist(cache_path, "Alpha", _token("AAA", "0x0000000000000000000000000000000000000001"))
+
+    assert TokenListManager().update_tokenlist("Alpha") is None
+
+
+def _write_tokenlist(cache_path, name, *tokens, **extra_data):
     cache_path.joinpath(f"{name}.json").write_text(
         json.dumps(
             {
@@ -105,6 +190,7 @@ def _write_tokenlist(cache_path, name, *tokens):
                 "timestamp": "2024-01-01T00:00:00Z",
                 "version": {"major": 1, "minor": 0, "patch": 0},
                 "tokens": list(tokens),
+                **extra_data,
             }
         )
     )

--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -79,6 +79,23 @@ def test_get_tokens_with_chain_id_none_returns_all_chains(tmp_path, monkeypatch)
     assert chain_ids == [1, 10]
 
 
+def test_get_token_info_supports_base58_addresses(tmp_path, monkeypatch):
+    cache_path = tmp_path.joinpath("cache")
+    cache_path.mkdir()
+    monkeypatch.setattr(config, "DEFAULT_CACHE_PATH", cache_path)
+    monkeypatch.chdir(tmp_path)
+
+    _write_tokenlist(
+        cache_path,
+        "Alpha",
+        _token("MICHI", "5mbK36SZ7J19An8jFochhQS4of8g6BwUjbeCSxBSoWdp", chain_id=501000101),
+    )
+
+    token_info = TokenListManager().get_token_info("MICHI")
+    assert token_info.address == "5mbK36SZ7J19An8jFochhQS4of8g6BwUjbeCSxBSoWdp"
+    assert token_info.chainId == 501000101
+
+
 def test_legacy_default_file_warns_and_migrates_order(tmp_path, monkeypatch):
     cache_path = tmp_path.joinpath("cache")
     cache_path.mkdir()

--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -222,6 +222,40 @@ def test_update_tokenlist_without_stored_source_url_returns_none(tmp_path, monke
     assert TokenListManager().update_tokenlist("Alpha") is None
 
 
+def test_install_writes_utf8_cache_file(tmp_path, monkeypatch):
+    cache_path = tmp_path.joinpath("cache")
+    cache_path.mkdir()
+    monkeypatch.setattr(config, "DEFAULT_CACHE_PATH", cache_path)
+    monkeypatch.chdir(tmp_path)
+
+    class FakeResponse:
+        text = ""
+        url = "https://example.com/tokenlist.json"
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {
+                "name": "Alpha",
+                "timestamp": "2024-01-01T00:00:00Z",
+                "version": {"major": 1, "minor": 0, "patch": 0},
+                "tokens": [
+                    {
+                        **_token("A\u0361LPHA", "0x0000000000000000000000000000000000000001"),
+                        "name": "Optimism \u0361 Token",
+                    }
+                ],
+            }
+
+    monkeypatch.setattr("tokenlists.manager.httpx.get", lambda *args, **kwargs: FakeResponse())
+
+    TokenListManager().install_tokenlist("https://example.com/install.json")
+
+    cached = cache_path.joinpath("Alpha.json").read_text(encoding="utf-8")
+    assert "A\u0361LPHA" in cached
+
+
 def _write_tokenlist(cache_path, name, *tokens, **extra_data):
     cache_path.joinpath(f"{name}.json").write_text(
         json.dumps(
@@ -232,7 +266,8 @@ def _write_tokenlist(cache_path, name, *tokens, **extra_data):
                 "tokens": list(tokens),
                 **extra_data,
             }
-        )
+        ),
+        encoding="utf-8",
     )
 
 

--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -2,8 +2,7 @@ import json
 
 import pytest
 
-from tokenlists import TokenListManager
-from tokenlists import config
+from tokenlists import TokenListManager, config
 
 
 def test_get_token_info_uses_local_pyproject_order(tmp_path, monkeypatch):
@@ -19,8 +18,12 @@ order = ["Beta", "Alpha"]
 """.strip()
     )
 
-    _write_tokenlist(cache_path, "Alpha", _token("TKN", "0x0000000000000000000000000000000000000001"))
-    _write_tokenlist(cache_path, "Beta", _token("TKN", "0x0000000000000000000000000000000000000002"))
+    _write_tokenlist(
+        cache_path, "Alpha", _token("TKN", "0x0000000000000000000000000000000000000001")
+    )
+    _write_tokenlist(
+        cache_path, "Beta", _token("TKN", "0x0000000000000000000000000000000000000002")
+    )
 
     token_info = TokenListManager().get_token_info("TKN")
     assert token_info.address == "0x0000000000000000000000000000000000000002"
@@ -39,8 +42,12 @@ order = ["Beta"]
 """.strip()
     )
 
-    _write_tokenlist(cache_path, "Alpha", _token("AAA", "0x0000000000000000000000000000000000000001"))
-    _write_tokenlist(cache_path, "Beta", _token("BBB", "0x0000000000000000000000000000000000000002"))
+    _write_tokenlist(
+        cache_path, "Alpha", _token("AAA", "0x0000000000000000000000000000000000000001")
+    )
+    _write_tokenlist(
+        cache_path, "Beta", _token("BBB", "0x0000000000000000000000000000000000000002")
+    )
 
     symbols = [token.symbol for token in TokenListManager().get_tokens()]
     assert symbols == ["BBB", "AAA"]
@@ -102,8 +109,12 @@ def test_legacy_default_file_warns_and_migrates_order(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "DEFAULT_CACHE_PATH", cache_path)
     monkeypatch.chdir(tmp_path)
 
-    _write_tokenlist(cache_path, "Alpha", _token("TKN", "0x0000000000000000000000000000000000000001"))
-    _write_tokenlist(cache_path, "Beta", _token("TKN", "0x0000000000000000000000000000000000000002"))
+    _write_tokenlist(
+        cache_path, "Alpha", _token("TKN", "0x0000000000000000000000000000000000000001")
+    )
+    _write_tokenlist(
+        cache_path, "Beta", _token("TKN", "0x0000000000000000000000000000000000000002")
+    )
     cache_path.joinpath(".default").write_text("Beta")
 
     with pytest.warns(FutureWarning, match="legacy `.default` tokenlist file is deprecated"):
@@ -135,12 +146,21 @@ def test_install_persists_resolved_source_url(tmp_path, monkeypatch):
                 "tokens": [_token("AAA", "0x0000000000000000000000000000000000000001")],
             }
 
-    monkeypatch.setattr("tokenlists.manager.requests.get", lambda uri: FakeResponse())
+    requested = {}
+
+    def fake_get(uri, **kwargs):
+        requested["uri"] = uri
+        requested["kwargs"] = kwargs
+        return FakeResponse()
+
+    monkeypatch.setattr("tokenlists.manager.httpx.get", fake_get)
 
     TokenListManager().install_tokenlist("https://example.com/install.json")
 
     cached = json.loads(cache_path.joinpath("Alpha.json").read_text())
     assert cached["tokenlistsSourceUrl"] == "https://example.com/tokenlist.json"
+    assert requested["uri"] == "https://example.com/install.json"
+    assert requested["kwargs"]["follow_redirects"] is True
 
 
 def test_update_tokenlist_uses_stored_source_url(tmp_path, monkeypatch):
@@ -173,11 +193,12 @@ def test_update_tokenlist_uses_stored_source_url(tmp_path, monkeypatch):
 
     called_uris = []
 
-    def fake_get(uri):
+    def fake_get(uri, **kwargs):
         called_uris.append(uri)
+        assert kwargs["follow_redirects"] is True
         return FakeResponse()
 
-    monkeypatch.setattr("tokenlists.manager.requests.get", fake_get)
+    monkeypatch.setattr("tokenlists.manager.httpx.get", fake_get)
 
     updated_name = TokenListManager().update_tokenlist("Alpha")
 
@@ -194,7 +215,9 @@ def test_update_tokenlist_without_stored_source_url_returns_none(tmp_path, monke
     monkeypatch.setattr(config, "DEFAULT_CACHE_PATH", cache_path)
     monkeypatch.chdir(tmp_path)
 
-    _write_tokenlist(cache_path, "Alpha", _token("AAA", "0x0000000000000000000000000000000000000001"))
+    _write_tokenlist(
+        cache_path, "Alpha", _token("AAA", "0x0000000000000000000000000000000000000001")
+    )
 
     assert TokenListManager().update_tokenlist("Alpha") is None
 

--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -46,6 +46,39 @@ order = ["Beta"]
     assert symbols == ["BBB", "AAA"]
 
 
+def test_get_token_info_defaults_to_any_chain(tmp_path, monkeypatch):
+    cache_path = tmp_path.joinpath("cache")
+    cache_path.mkdir()
+    monkeypatch.setattr(config, "DEFAULT_CACHE_PATH", cache_path)
+    monkeypatch.chdir(tmp_path)
+
+    _write_tokenlist(
+        cache_path,
+        "Alpha",
+        _token("TKN", "0x0000000000000000000000000000000000000001", chain_id=137),
+    )
+
+    token_info = TokenListManager().get_token_info("TKN")
+    assert token_info.chainId == 137
+
+
+def test_get_tokens_with_chain_id_none_returns_all_chains(tmp_path, monkeypatch):
+    cache_path = tmp_path.joinpath("cache")
+    cache_path.mkdir()
+    monkeypatch.setattr(config, "DEFAULT_CACHE_PATH", cache_path)
+    monkeypatch.chdir(tmp_path)
+
+    _write_tokenlist(
+        cache_path,
+        "Alpha",
+        _token("AAA", "0x0000000000000000000000000000000000000001", chain_id=1),
+        _token("BBB", "0x0000000000000000000000000000000000000002", chain_id=10),
+    )
+
+    chain_ids = [token.chainId for token in TokenListManager().get_tokens(chain_id=None)]
+    assert chain_ids == [1, 10]
+
+
 def test_legacy_default_file_warns_and_migrates_order(tmp_path, monkeypatch):
     cache_path = tmp_path.joinpath("cache")
     cache_path.mkdir()
@@ -64,22 +97,22 @@ def test_legacy_default_file_warns_and_migrates_order(tmp_path, monkeypatch):
     assert manager.get_token_info("TKN").address == "0x0000000000000000000000000000000000000002"
 
 
-def _write_tokenlist(cache_path, name, token):
+def _write_tokenlist(cache_path, name, *tokens):
     cache_path.joinpath(f"{name}.json").write_text(
         json.dumps(
             {
                 "name": name,
                 "timestamp": "2024-01-01T00:00:00Z",
                 "version": {"major": 1, "minor": 0, "patch": 0},
-                "tokens": [token],
+                "tokens": list(tokens),
             }
         )
     )
 
 
-def _token(symbol, address):
+def _token(symbol, address, chain_id=1):
     return {
-        "chainId": 1,
+        "chainId": chain_id,
         "address": address,
         "name": symbol,
         "decimals": 18,

--- a/tests/integration/test_manager.py
+++ b/tests/integration/test_manager.py
@@ -1,0 +1,87 @@
+import json
+
+import pytest
+
+from tokenlists import TokenListManager
+from tokenlists import config
+
+
+def test_get_token_info_uses_local_pyproject_order(tmp_path, monkeypatch):
+    cache_path = tmp_path.joinpath("cache")
+    cache_path.mkdir()
+    monkeypatch.setattr(config, "DEFAULT_CACHE_PATH", cache_path)
+    monkeypatch.chdir(tmp_path)
+
+    tmp_path.joinpath("pyproject.toml").write_text(
+        """
+[tool.tokenlists]
+order = ["Beta", "Alpha"]
+""".strip()
+    )
+
+    _write_tokenlist(cache_path, "Alpha", _token("TKN", "0x0000000000000000000000000000000000000001"))
+    _write_tokenlist(cache_path, "Beta", _token("TKN", "0x0000000000000000000000000000000000000002"))
+
+    token_info = TokenListManager().get_token_info("TKN")
+    assert token_info.address == "0x0000000000000000000000000000000000000002"
+
+
+def test_get_tokens_without_name_iterates_across_configured_order(tmp_path, monkeypatch):
+    cache_path = tmp_path.joinpath("cache")
+    cache_path.mkdir()
+    monkeypatch.setattr(config, "DEFAULT_CACHE_PATH", cache_path)
+    monkeypatch.chdir(tmp_path)
+
+    tmp_path.joinpath("pyproject.toml").write_text(
+        """
+[tool.tokenlists]
+order = ["Beta"]
+""".strip()
+    )
+
+    _write_tokenlist(cache_path, "Alpha", _token("AAA", "0x0000000000000000000000000000000000000001"))
+    _write_tokenlist(cache_path, "Beta", _token("BBB", "0x0000000000000000000000000000000000000002"))
+
+    symbols = [token.symbol for token in TokenListManager().get_tokens()]
+    assert symbols == ["BBB", "AAA"]
+
+
+def test_legacy_default_file_warns_and_migrates_order(tmp_path, monkeypatch):
+    cache_path = tmp_path.joinpath("cache")
+    cache_path.mkdir()
+    monkeypatch.setattr(config, "DEFAULT_CACHE_PATH", cache_path)
+    monkeypatch.chdir(tmp_path)
+
+    _write_tokenlist(cache_path, "Alpha", _token("TKN", "0x0000000000000000000000000000000000000001"))
+    _write_tokenlist(cache_path, "Beta", _token("TKN", "0x0000000000000000000000000000000000000002"))
+    cache_path.joinpath(".default").write_text("Beta")
+
+    with pytest.warns(FutureWarning, match="legacy `.default` tokenlist file is deprecated"):
+        manager = TokenListManager()
+
+    assert cache_path.joinpath(".default").exists()
+    assert manager.available_tokenlists() == ["Beta", "Alpha"]
+    assert manager.get_token_info("TKN").address == "0x0000000000000000000000000000000000000002"
+
+
+def _write_tokenlist(cache_path, name, token):
+    cache_path.joinpath(f"{name}.json").write_text(
+        json.dumps(
+            {
+                "name": name,
+                "timestamp": "2024-01-01T00:00:00Z",
+                "version": {"major": 1, "minor": 0, "patch": 0},
+                "tokens": [token],
+            }
+        )
+    )
+
+
+def _token(symbol, address):
+    return {
+        "chainId": 1,
+        "address": address,
+        "name": symbol,
+        "decimals": 18,
+        "symbol": symbol,
+    }

--- a/tests/integration/test_suggested_tokenlists.py
+++ b/tests/integration/test_suggested_tokenlists.py
@@ -1,0 +1,17 @@
+import pytest
+
+from tokenlists import TokenListManager, config
+
+
+@pytest.mark.parametrize("uri", list(config.get_suggested_tokenlists()))
+def test_suggested_tokenlists_install(uri, tmp_path, monkeypatch):
+    cache_path = tmp_path.joinpath("cache")
+    cache_path.mkdir()
+    monkeypatch.setattr(config, "DEFAULT_CACHE_PATH", cache_path)
+    monkeypatch.chdir(tmp_path)
+
+    manager = TokenListManager()
+    installed_name = manager.install_tokenlist(uri)
+
+    assert installed_name in manager.available_tokenlists()
+    assert cache_path.joinpath(f"{installed_name}.json").exists()

--- a/tokenlists/__main__.py
+++ b/tokenlists/__main__.py
@@ -53,6 +53,31 @@ def remove(name):
     manager.remove_tokenlist(name)
 
 
+@cli.command(short_help="Update installed tokenlists from their stored source URLs")
+@click.argument("name", type=TokenlistChoice(), required=False)
+@click.option("--all", "update_all", default=False, is_flag=True)
+def update(name, update_all):
+    manager = TokenListManager()
+
+    if not manager.available_tokenlists():
+        raise click.ClickException("No tokenlists available!")
+
+    if update_all == bool(name):
+        raise click.ClickException("Provide either a tokenlist name or `--all`.")
+
+    tokenlist_names = manager.available_tokenlists() if update_all else [name]
+    for tokenlist_name in tokenlist_names:
+        updated_name = manager.update_tokenlist(tokenlist_name)
+        if updated_name is None:
+            click.echo(
+                f"WARNING: Token list '{tokenlist_name}' does not have a stored source URL and cannot be updated."
+            )
+        elif updated_name == tokenlist_name:
+            click.echo(f"Updated '{tokenlist_name}'.")
+        else:
+            click.echo(f"Updated '{tokenlist_name}' as '{updated_name}'.")
+
+
 @cli.command(short_help="Display the names and versions of all installed tokenlists")
 @click.option("--search", default="")
 @click.option("--tokenlist-name", type=TokenlistChoice(), default=None)

--- a/tokenlists/__main__.py
+++ b/tokenlists/__main__.py
@@ -103,3 +103,7 @@ def token_info(symbol, tokenlist_name, chain_id, case_insensitive):
         Tags: {tags}
     """.format(**token_info)
     )
+
+
+if __name__ == "__main__":
+    cli()

--- a/tokenlists/__main__.py
+++ b/tokenlists/__main__.py
@@ -4,6 +4,7 @@ import re
 
 import click
 
+from . import config
 from .manager import TokenListManager
 from .typing import TokenSymbol
 
@@ -36,10 +37,20 @@ def _list():
             click.echo(f"- {tokenlist.name} (v{tokenlist.version})")
 
     else:
-        click.echo("WARNING: No tokenlists exist!")
+        click.echo("WARNING: No tokenlists exist! Run `tokenlists suggestions` to browse installable lists.")
 
 
-@cli.command(short_help="Install a new tokenlist")
+@cli.command(short_help="Display suggested tokenlists you can install")
+def suggestions():
+    click.echo("Suggested Token Lists:")
+    click.echo(f"Source: {config.SUGGESTED_TOKENLISTS_SOURCE_URL}")
+    for uri, metadata in config.get_suggested_tokenlists().items():
+        homepage = metadata.get("homepage")
+        suffix = f" [{homepage}]" if homepage else ""
+        click.echo(f"- {metadata['name']}: {uri}{suffix}")
+
+
+@cli.command(short_help="Install a tokenlist from a URI or ENS name")
 @click.argument("uri")
 def install(uri):
     manager = TokenListManager()

--- a/tokenlists/__main__.py
+++ b/tokenlists/__main__.py
@@ -37,7 +37,10 @@ def _list():
             click.echo(f"- {tokenlist.name} (v{tokenlist.version})")
 
     else:
-        click.echo("WARNING: No tokenlists exist! Run `tokenlists suggestions` to browse installable lists.")
+        click.echo(
+            "WARNING: No tokenlists exist! "
+            "Run `tokenlists suggestions` to browse installable lists."
+        )
 
 
 @cli.command(short_help="Display suggested tokenlists you can install")
@@ -81,7 +84,8 @@ def update(name, update_all):
         updated_name = manager.update_tokenlist(tokenlist_name)
         if updated_name is None:
             click.echo(
-                f"WARNING: Token list '{tokenlist_name}' does not have a stored source URL and cannot be updated."
+                f"WARNING: Token list '{tokenlist_name}' does not have a stored "
+                "source URL and cannot be updated."
             )
         elif updated_name == tokenlist_name:
             click.echo(f"Updated '{tokenlist_name}'.")

--- a/tokenlists/_cli.py
+++ b/tokenlists/_cli.py
@@ -56,7 +56,7 @@ def remove(name):
 @cli.command(short_help="Display the names and versions of all installed tokenlists")
 @click.option("--search", default="")
 @click.option("--tokenlist-name", type=TokenlistChoice(), default=None)
-@click.option("--chain-id", default=1, type=int)
+@click.option("--chain-id", default=None, type=int)
 def list_tokens(search, tokenlist_name, chain_id):
     manager = TokenListManager()
 
@@ -76,15 +76,18 @@ def list_tokens(search, tokenlist_name, chain_id):
 @click.argument("symbol", type=TokenSymbol)
 @click.option("--tokenlist-name", type=TokenlistChoice(), default=None)
 @click.option("--case-insensitive", default=False, is_flag=True)
-@click.option("--chain-id", default=1, type=int)
+@click.option("--chain-id", default=None, type=int)
 def token_info(symbol, tokenlist_name, chain_id, case_insensitive):
     manager = TokenListManager()
 
     if not manager.available_tokenlists():
         raise click.ClickException("No tokenlists available!")
 
-    token_info = manager.get_token_info(symbol, tokenlist_name, chain_id, case_insensitive)
+    tokenlist_name, token_info = manager.get_token_info_with_tokenlist(
+        symbol, tokenlist_name, chain_id, case_insensitive
+    )
     token_info = token_info.model_dump(mode="json")
+    token_info["tokenlist_name"] = tokenlist_name
 
     if "tags" not in token_info:
         token_info["tags"] = ""
@@ -93,6 +96,7 @@ def token_info(symbol, tokenlist_name, chain_id, case_insensitive):
         """
       Symbol: {symbol}
         Name: {name}
+  Token List: {tokenlist_name}
     Chain ID: {chainId}
      Address: {address}
     Decimals: {decimals}

--- a/tokenlists/_cli.py
+++ b/tokenlists/_cli.py
@@ -53,14 +53,6 @@ def remove(name):
     manager.remove_tokenlist(name)
 
 
-@cli.command(short_help="Set the default tokenlist")
-@click.argument("name", type=TokenlistChoice())
-def set_default(name):
-    manager = TokenListManager()
-    manager.set_default_tokenlist(name)
-    click.echo(f"Default tokenlist is now: '{manager.default_tokenlist}'")
-
-
 @cli.command(short_help="Display the names and versions of all installed tokenlists")
 @click.option("--search", default="")
 @click.option("--tokenlist-name", type=TokenlistChoice(), default=None)
@@ -68,7 +60,7 @@ def set_default(name):
 def list_tokens(search, tokenlist_name, chain_id):
     manager = TokenListManager()
 
-    if not manager.default_tokenlist:
+    if not manager.available_tokenlists():
         raise click.ClickException("No tokenlists available!")
 
     pattern = re.compile(search or ".*")
@@ -88,7 +80,7 @@ def list_tokens(search, tokenlist_name, chain_id):
 def token_info(symbol, tokenlist_name, chain_id, case_insensitive):
     manager = TokenListManager()
 
-    if not manager.default_tokenlist:
+    if not manager.available_tokenlists():
         raise click.ClickException("No tokenlists available!")
 
     token_info = manager.get_token_info(symbol, tokenlist_name, chain_id, case_insensitive)

--- a/tokenlists/config.py
+++ b/tokenlists/config.py
@@ -1,11 +1,12 @@
 import json
+import sys
 from importlib import resources
 from pathlib import Path
 from typing import Any
 
-try:
+if sys.version_info >= (3, 11):
     import tomllib
-except ModuleNotFoundError:  # pragma: no cover
+else:  # pragma: no cover
     import tomli as tomllib
 
 DEFAULT_CACHE_PATH = Path.home().joinpath(".tokenlists")

--- a/tokenlists/config.py
+++ b/tokenlists/config.py
@@ -1,3 +1,5 @@
+import json
+from importlib import resources
 from pathlib import Path
 from typing import Any
 
@@ -9,6 +11,9 @@ except ModuleNotFoundError:  # pragma: no cover
 DEFAULT_CACHE_PATH = Path.home().joinpath(".tokenlists")
 
 UNISWAP_ENS_TOKENLISTS_HOST = "https://wispy-bird-88a7.uniswap.workers.dev/?url=http://{}.link"
+SUGGESTED_TOKENLISTS_SOURCE_URL = (
+    "https://raw.githubusercontent.com/Uniswap/tokenlists-org/master/src/token-lists.json"
+)
 
 
 def get_local_tokenlists_config() -> dict[str, Any] | None:
@@ -37,6 +42,11 @@ def get_tokenlist_order() -> list[str] | None:
         )
 
     return order
+
+
+def get_suggested_tokenlists() -> dict[str, dict[str, str]]:
+    suggested_tokenlists = resources.files("tokenlists").joinpath("suggested.json")
+    return json.loads(suggested_tokenlists.read_text())
 
 
 def _find_local_pyproject_path() -> Path | None:

--- a/tokenlists/config.py
+++ b/tokenlists/config.py
@@ -1,6 +1,49 @@
 from pathlib import Path
+from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
 
 DEFAULT_CACHE_PATH = Path.home().joinpath(".tokenlists")
-DEFAULT_TOKENLIST: str | None = None
 
 UNISWAP_ENS_TOKENLISTS_HOST = "https://wispy-bird-88a7.uniswap.workers.dev/?url=http://{}.link"
+
+
+def get_local_tokenlists_config() -> dict[str, Any] | None:
+    pyproject_path = _find_local_pyproject_path()
+    if pyproject_path is None:
+        return None
+
+    data = tomllib.loads(pyproject_path.read_text())
+    tool_config = data.get("tool", {})
+    if not isinstance(tool_config, dict):
+        return None
+
+    tokenlists_config = tool_config.get("tokenlists")
+    return tokenlists_config if isinstance(tokenlists_config, dict) else None
+
+
+def get_tokenlist_order() -> list[str] | None:
+    tokenlists_config = get_local_tokenlists_config()
+    if tokenlists_config is None:
+        return None
+
+    order = tokenlists_config.get("order", [])
+    if not isinstance(order, list) or not all(isinstance(item, str) for item in order):
+        raise ValueError(
+            "Expected `[tool.tokenlists].order` in `pyproject.toml` to be a list of strings."
+        )
+
+    return order
+
+
+def _find_local_pyproject_path() -> Path | None:
+    current_path = Path.cwd().resolve()
+    for directory in (current_path, *current_path.parents):
+        pyproject_path = directory.joinpath("pyproject.toml")
+        if pyproject_path.is_file():
+            return pyproject_path
+
+    return None

--- a/tokenlists/config.py
+++ b/tokenlists/config.py
@@ -22,7 +22,7 @@ def get_local_tokenlists_config() -> dict[str, Any] | None:
     if pyproject_path is None:
         return None
 
-    data = tomllib.loads(pyproject_path.read_text())
+    data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
     tool_config = data.get("tool", {})
     if not isinstance(tool_config, dict):
         return None
@@ -47,7 +47,7 @@ def get_tokenlist_order() -> list[str] | None:
 
 def get_suggested_tokenlists() -> dict[str, dict[str, str]]:
     suggested_tokenlists = resources.files("tokenlists").joinpath("suggested.json")
-    return json.loads(suggested_tokenlists.read_text())
+    return json.loads(suggested_tokenlists.read_text(encoding="utf-8"))
 
 
 def _find_local_pyproject_path() -> Path | None:

--- a/tokenlists/manager.py
+++ b/tokenlists/manager.py
@@ -71,20 +71,35 @@ class TokenListManager:
     def get_tokens(
         self,
         token_listname: str | None = None,
-        chain_id: ChainId = 1,  # Ethereum Mainnnet
+        chain_id: ChainId | None = None,
     ) -> Iterator[TokenInfo]:
         for tokenlist in self._iter_tokenlists(token_listname):
             for token in tokenlist.tokens:
-                if token.chainId == chain_id:
+                if chain_id is None or token.chainId == chain_id:
                     yield token
 
     def get_token_info(
         self,
         symbol: TokenSymbol,
         token_listname: str | None = None,
-        chain_id: ChainId = 1,  # Ethereum Mainnnet
+        chain_id: ChainId | None = None,
         case_insensitive: bool = False,
     ) -> TokenInfo:
+        _, token_info = self.get_token_info_with_tokenlist(
+            symbol,
+            token_listname=token_listname,
+            chain_id=chain_id,
+            case_insensitive=case_insensitive,
+        )
+        return token_info
+
+    def get_token_info_with_tokenlist(
+        self,
+        symbol: TokenSymbol,
+        token_listname: str | None = None,
+        chain_id: ChainId | None = None,
+        case_insensitive: bool = False,
+    ) -> tuple[str, TokenInfo]:
         for tokenlist in self._iter_tokenlists(token_listname):
             matching_tokens = self._get_matching_tokens(
                 tokenlist, symbol, chain_id, case_insensitive
@@ -97,7 +112,7 @@ class TokenListManager:
                     f"Multiple tokens with symbol '{symbol}' found in '{tokenlist.name}' token list."
                 )
 
-            return matching_tokens[0]
+            return tokenlist.name, matching_tokens[0]
 
         if token_listname:
             raise ValueError(
@@ -153,10 +168,14 @@ class TokenListManager:
         self,
         tokenlist: TokenList,
         symbol: TokenSymbol,
-        chain_id: ChainId,
+        chain_id: ChainId | None,
         case_insensitive: bool,
     ) -> list[TokenInfo]:
-        token_iter = filter(lambda t: t.chainId == chain_id, tokenlist.tokens)
+        token_iter = (
+            filter(lambda t: t.chainId == chain_id, tokenlist.tokens)
+            if chain_id is not None
+            else iter(tokenlist.tokens)
+        )
         token_iter = (
             filter(lambda t: t.symbol.lower() == symbol.lower(), token_iter)
             if case_insensitive

--- a/tokenlists/manager.py
+++ b/tokenlists/manager.py
@@ -20,7 +20,7 @@ class TokenListManager:
         # Load all the ones cached on disk
         self.installed_tokenlists = {}
         for path in sorted(self.cache_folder.glob("*.json")):
-            tokenlist = TokenList.model_validate_json(path.read_text())
+            tokenlist = TokenList.model_validate_json(path.read_text(encoding="utf-8"))
             self.installed_tokenlists[tokenlist.name] = tokenlist
 
         self.tokenlist_order = self._build_tokenlist_order()
@@ -139,7 +139,7 @@ class TokenListManager:
         if not default_tokenlist_cachefile.exists():
             return installed_names
 
-        legacy_default = default_tokenlist_cachefile.read_text().strip()
+        legacy_default = default_tokenlist_cachefile.read_text(encoding="utf-8").strip()
         warnings.warn(
             (
                 "The legacy `.default` tokenlist file is deprecated. "
@@ -166,7 +166,7 @@ class TokenListManager:
 
         self.installed_tokenlists[tokenlist.name] = tokenlist
         token_list_file = self.cache_folder.joinpath(f"{tokenlist.name}.json")
-        token_list_file.write_text(tokenlist.model_dump_json())
+        token_list_file.write_text(tokenlist.model_dump_json(), encoding="utf-8")
         self.tokenlist_order = self._build_tokenlist_order()
 
     def _fetch_tokenlist(self, uri: str) -> tuple[TokenList, str]:

--- a/tokenlists/manager.py
+++ b/tokenlists/manager.py
@@ -1,13 +1,14 @@
+import warnings
 from collections.abc import Iterator
 from json import JSONDecodeError
-import warnings
 
-import requests
+import httpx
 
 from tokenlists import config
 from tokenlists.typing import ChainId, TokenInfo, TokenList, TokenSymbol
 
 SOURCE_URI_FIELD = "tokenlistsSourceUrl"
+HTTP_TIMEOUT = 30.0
 
 
 class TokenListManager:
@@ -114,7 +115,9 @@ class TokenListManager:
                 f"Token with symbol '{symbol}' does not exist within '{token_listname}' token list."
             )
 
-        raise ValueError(f"Token with symbol '{symbol}' does not exist within installed token lists.")
+        raise ValueError(
+            f"Token with symbol '{symbol}' does not exist within installed token lists."
+        )
 
     def _build_tokenlist_order(self) -> list[str]:
         installed_names = list(self.installed_tokenlists)
@@ -166,9 +169,15 @@ class TokenListManager:
         self.tokenlist_order = self._build_tokenlist_order()
 
     def _fetch_tokenlist(self, uri: str) -> tuple[TokenList, str]:
-        resolved_uri = config.UNISWAP_ENS_TOKENLISTS_HOST.format(uri) if uri.endswith(".eth") else uri
+        resolved_uri = (
+            config.UNISWAP_ENS_TOKENLISTS_HOST.format(uri) if uri.endswith(".eth") else uri
+        )
 
-        response = requests.get(resolved_uri)
+        response = httpx.get(
+            resolved_uri,
+            follow_redirects=True,
+            timeout=HTTP_TIMEOUT,
+        )
         response.raise_for_status()
         try:
             response_json = response.json()

--- a/tokenlists/manager.py
+++ b/tokenlists/manager.py
@@ -7,6 +7,8 @@ import requests
 from tokenlists import config
 from tokenlists.typing import ChainId, TokenInfo, TokenList, TokenSymbol
 
+SOURCE_URI_FIELD = "tokenlistsSourceUrl"
+
 
 class TokenListManager:
     def __init__(self):
@@ -27,28 +29,21 @@ class TokenListManager:
         Install the tokenlist at the given URI, return the name of the installed list
         (for reference purposes)
         """
-        # This supports ENS lists
-        if uri.endswith(".eth"):
-            uri = config.UNISWAP_ENS_TOKENLISTS_HOST.format(uri)
-
-        # Load and store the tokenlist
-        response = requests.get(uri)
-        response.raise_for_status()
-        try:
-            response_json = response.json()
-        except JSONDecodeError as err:
-            raise ValueError(f"Invalid response: {response.text}") from err
-
-        tokenlist = TokenList.model_validate(response_json)
-        self.installed_tokenlists[tokenlist.name] = tokenlist
-        self.tokenlist_order = self._build_tokenlist_order()
-
-        # Cache it on disk for later instances
-        self.cache_folder.mkdir(exist_ok=True)
-        token_list_file = self.cache_folder.joinpath(f"{tokenlist.name}.json")
-        token_list_file.write_text(tokenlist.model_dump_json())
-
+        tokenlist, source_uri = self._fetch_tokenlist(uri)
+        self._set_source_uri(tokenlist, source_uri)
+        self._cache_tokenlist(tokenlist)
         return tokenlist.name
+
+    def update_tokenlist(self, tokenlist_name: str) -> str | None:
+        tokenlist = self.get_tokenlist(tokenlist_name)
+        source_uri = self._get_source_uri(tokenlist)
+        if not source_uri:
+            return None
+
+        updated_tokenlist, resolved_source_uri = self._fetch_tokenlist(source_uri)
+        self._set_source_uri(updated_tokenlist, resolved_source_uri)
+        self._cache_tokenlist(updated_tokenlist, previous_name=tokenlist_name)
+        return updated_tokenlist.name
 
     def remove_tokenlist(self, tokenlist_name: str) -> None:
         tokenlist = self.installed_tokenlists[tokenlist_name]
@@ -155,6 +150,40 @@ class TokenListManager:
             return [legacy_default, *(name for name in installed_names if name != legacy_default)]
 
         return installed_names
+
+    def _cache_tokenlist(self, tokenlist: TokenList, previous_name: str | None = None) -> None:
+        self.cache_folder.mkdir(exist_ok=True)
+
+        if previous_name and previous_name != tokenlist.name:
+            previous_token_list_file = self.cache_folder.joinpath(f"{previous_name}.json")
+            if previous_token_list_file.exists():
+                previous_token_list_file.unlink()
+            self.installed_tokenlists.pop(previous_name, None)
+
+        self.installed_tokenlists[tokenlist.name] = tokenlist
+        token_list_file = self.cache_folder.joinpath(f"{tokenlist.name}.json")
+        token_list_file.write_text(tokenlist.model_dump_json())
+        self.tokenlist_order = self._build_tokenlist_order()
+
+    def _fetch_tokenlist(self, uri: str) -> tuple[TokenList, str]:
+        resolved_uri = config.UNISWAP_ENS_TOKENLISTS_HOST.format(uri) if uri.endswith(".eth") else uri
+
+        response = requests.get(resolved_uri)
+        response.raise_for_status()
+        try:
+            response_json = response.json()
+        except JSONDecodeError as err:
+            raise ValueError(f"Invalid response: {response.text}") from err
+
+        tokenlist = TokenList.model_validate(response_json)
+        return tokenlist, str(response.url or resolved_uri)
+
+    def _get_source_uri(self, tokenlist: TokenList) -> str | None:
+        source_uri = getattr(tokenlist, SOURCE_URI_FIELD, None)
+        return source_uri if isinstance(source_uri, str) and source_uri else None
+
+    def _set_source_uri(self, tokenlist: TokenList, source_uri: str) -> None:
+        setattr(tokenlist, SOURCE_URI_FIELD, source_uri)
 
     def _iter_tokenlists(self, token_listname: str | None = None) -> Iterator[TokenList]:
         if token_listname:

--- a/tokenlists/manager.py
+++ b/tokenlists/manager.py
@@ -105,7 +105,8 @@ class TokenListManager:
 
             if len(matching_tokens) > 1:
                 raise ValueError(
-                    f"Multiple tokens with symbol '{symbol}' found in '{tokenlist.name}' token list."
+                    f"Multiple tokens with symbol '{symbol}' found in "
+                    f"'{tokenlist.name}' token list."
                 )
 
             return tokenlist.name, matching_tokens[0]

--- a/tokenlists/manager.py
+++ b/tokenlists/manager.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterator
 from json import JSONDecodeError
+import warnings
 
 import requests
 
@@ -15,21 +16,11 @@ class TokenListManager:
 
         # Load all the ones cached on disk
         self.installed_tokenlists = {}
-        for path in self.cache_folder.glob("*.json"):
+        for path in sorted(self.cache_folder.glob("*.json")):
             tokenlist = TokenList.model_validate_json(path.read_text())
             self.installed_tokenlists[tokenlist.name] = tokenlist
 
-        self.default_tokenlist = config.DEFAULT_TOKENLIST
-        if not self.default_tokenlist:
-            # Default might be cached on disk (does not override config)
-            default_tokenlist_cachefile = self.cache_folder.joinpath(".default")
-
-            if default_tokenlist_cachefile.exists():
-                self.default_tokenlist = default_tokenlist_cachefile.read_text()
-
-            elif len(self.installed_tokenlists) > 0:
-                # Not cached on disk, use first installed list
-                self.default_tokenlist = next(iter(self.installed_tokenlists))
+        self.tokenlist_order = self._build_tokenlist_order()
 
     def install_tokenlist(self, uri: str) -> str:
         """
@@ -50,6 +41,7 @@ class TokenListManager:
 
         tokenlist = TokenList.model_validate(response_json)
         self.installed_tokenlists[tokenlist.name] = tokenlist
+        self.tokenlist_order = self._build_tokenlist_order()
 
         # Cache it on disk for later instances
         self.cache_folder.mkdir(exist_ok=True)
@@ -61,34 +53,16 @@ class TokenListManager:
     def remove_tokenlist(self, tokenlist_name: str) -> None:
         tokenlist = self.installed_tokenlists[tokenlist_name]
 
-        if tokenlist.name == self.default_tokenlist:
-            self.default_tokenlist = ""
-
         token_list_file = self.cache_folder.joinpath(f"{tokenlist.name}.json")
         token_list_file.unlink()
 
         del self.installed_tokenlists[tokenlist.name]
-
-    def set_default_tokenlist(self, name: str) -> None:
-        if name not in self.installed_tokenlists:
-            raise ValueError(f"Unknown token list: {name}")
-
-        self.default_tokenlist = name
-
-        # Cache it on disk too
-        self.cache_folder.mkdir(exist_ok=True)
-        self.cache_folder.joinpath(".default").write_text(name)
+        self.tokenlist_order = self._build_tokenlist_order()
 
     def available_tokenlists(self) -> list[str]:
-        return sorted(self.installed_tokenlists)
+        return list(self.tokenlist_order)
 
-    def get_tokenlist(self, token_listname: str | None = None) -> TokenList:
-        if not token_listname:
-            if not self.default_tokenlist:
-                raise ValueError("Default token list has not been set.")
-
-            token_listname = self.default_tokenlist
-
+    def get_tokenlist(self, token_listname: str) -> TokenList:
         if token_listname not in self.installed_tokenlists:
             raise ValueError(f"Unknown token list: {token_listname}")
 
@@ -96,38 +70,96 @@ class TokenListManager:
 
     def get_tokens(
         self,
-        token_listname: str | None = None,  # Use default
+        token_listname: str | None = None,
         chain_id: ChainId = 1,  # Ethereum Mainnnet
     ) -> Iterator[TokenInfo]:
-        tokenlist = self.get_tokenlist(token_listname)
-        return filter(lambda t: t.chainId == chain_id, tokenlist.tokens)
+        for tokenlist in self._iter_tokenlists(token_listname):
+            for token in tokenlist.tokens:
+                if token.chainId == chain_id:
+                    yield token
 
     def get_token_info(
         self,
         symbol: TokenSymbol,
-        token_listname: str | None = None,  # Use default
+        token_listname: str | None = None,
         chain_id: ChainId = 1,  # Ethereum Mainnnet
         case_insensitive: bool = False,
     ) -> TokenInfo:
-        tokenlist = self.get_tokenlist(token_listname)
+        for tokenlist in self._iter_tokenlists(token_listname):
+            matching_tokens = self._get_matching_tokens(
+                tokenlist, symbol, chain_id, case_insensitive
+            )
+            if len(matching_tokens) == 0:
+                continue
 
-        token_iter = filter(lambda t: t.chainId == chain_id, tokenlist.tokens)
-        token_iter = (
-            filter(lambda t: t.symbol == symbol, token_iter)
-            if case_insensitive
-            else filter(lambda t: t.symbol.lower() == symbol.lower(), token_iter)
+            if len(matching_tokens) > 1:
+                raise ValueError(
+                    f"Multiple tokens with symbol '{symbol}' found in '{tokenlist.name}' token list."
+                )
+
+            return matching_tokens[0]
+
+        if token_listname:
+            raise ValueError(
+                f"Token with symbol '{symbol}' does not exist within '{token_listname}' token list."
+            )
+
+        raise ValueError(f"Token with symbol '{symbol}' does not exist within installed token lists.")
+
+    def _build_tokenlist_order(self) -> list[str]:
+        installed_names = list(self.installed_tokenlists)
+        configured_order = config.get_tokenlist_order()
+        if configured_order is not None:
+            ordered_names = []
+            for name in configured_order:
+                if name in self.installed_tokenlists and name not in ordered_names:
+                    ordered_names.append(name)
+
+            ordered_names.extend(name for name in installed_names if name not in ordered_names)
+            return ordered_names
+
+        return self._build_legacy_tokenlist_order(installed_names)
+
+    def _build_legacy_tokenlist_order(self, installed_names: list[str]) -> list[str]:
+        default_tokenlist_cachefile = self.cache_folder.joinpath(".default")
+        if not default_tokenlist_cachefile.exists():
+            return installed_names
+
+        legacy_default = default_tokenlist_cachefile.read_text().strip()
+        warnings.warn(
+            (
+                "The legacy `.default` tokenlist file is deprecated. "
+                "Move your preferred ordering into `[tool.tokenlists].order` in `pyproject.toml`. "
+                "Support for `.default` will be removed in an upcoming version."
+            ),
+            FutureWarning,
+            stacklevel=2,
         )
 
-        matching_tokens = list(token_iter)
-        if len(matching_tokens) == 0:
-            raise ValueError(
-                f"Token with symbol '{symbol}' does not exist within '{tokenlist.name}' token list."
-            )
+        if legacy_default in self.installed_tokenlists:
+            return [legacy_default, *(name for name in installed_names if name != legacy_default)]
 
-        elif len(matching_tokens) > 1:
-            raise ValueError(
-                f"Multiple tokens with symbol '{symbol}' found in '{tokenlist.name}' token list."
-            )
+        return installed_names
 
-        else:
-            return matching_tokens[0]
+    def _iter_tokenlists(self, token_listname: str | None = None) -> Iterator[TokenList]:
+        if token_listname:
+            yield self.get_tokenlist(token_listname)
+            return
+
+        for name in self.tokenlist_order:
+            yield self.installed_tokenlists[name]
+
+    def _get_matching_tokens(
+        self,
+        tokenlist: TokenList,
+        symbol: TokenSymbol,
+        chain_id: ChainId,
+        case_insensitive: bool,
+    ) -> list[TokenInfo]:
+        token_iter = filter(lambda t: t.chainId == chain_id, tokenlist.tokens)
+        token_iter = (
+            filter(lambda t: t.symbol.lower() == symbol.lower(), token_iter)
+            if case_insensitive
+            else filter(lambda t: t.symbol == symbol, token_iter)
+        )
+        return list(token_iter)

--- a/tokenlists/suggested.json
+++ b/tokenlists/suggested.json
@@ -7,10 +7,6 @@
     "name": "CoinGecko",
     "homepage": ""
   },
-  "https://defiprime.com/defiprime.tokenlist.json": {
-    "name": "Defiprime",
-    "homepage": ""
-  },
   "t2crtokens.eth": {
     "name": "Kleros T2CR",
     "homepage": ""

--- a/tokenlists/suggested.json
+++ b/tokenlists/suggested.json
@@ -1,0 +1,26 @@
+{
+  "tokens.1inch.eth": {
+    "name": "1inch",
+    "homepage": ""
+  },
+  "https://tokens.coingecko.com/uniswap/all.json": {
+    "name": "CoinGecko",
+    "homepage": ""
+  },
+  "https://defiprime.com/defiprime.tokenlist.json": {
+    "name": "Defiprime",
+    "homepage": ""
+  },
+  "t2crtokens.eth": {
+    "name": "Kleros T2CR",
+    "homepage": ""
+  },
+  "https://static.optimism.io/optimism.tokenlist.json": {
+    "name": "Optimism",
+    "homepage": "https://optimism.io/"
+  },
+  "https://ipfs.io/ipns/tokens.uniswap.org": {
+    "name": "Uniswap Default List",
+    "homepage": ""
+  }
+}

--- a/tokenlists/typing.py
+++ b/tokenlists/typing.py
@@ -10,6 +10,8 @@ TokenAddress = str
 TokenName = str
 TokenDecimals = int
 TokenSymbol = str
+BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+BASE58_CHARACTERS = set(BASE58_ALPHABET)
 
 
 class BaseModel(_BaseModel):
@@ -96,16 +98,48 @@ class TokenInfo(BaseModel):
         return None
 
     @field_validator("address")
-    def address_must_hex(cls, v: str):
-        if not v.startswith("0x") or set(v) > set("x0123456789abcdefABCDEF") or len(v) % 2 != 0:
+    def address_must_be_supported_format(cls, value: str) -> str:
+        if value.startswith("0x"):
+            return cls._validate_hex_address(value)
+
+        if cls._is_base58_address(value):
+            return value
+
+        raise ValueError("Address is not a supported hex or base58 value")
+
+    @classmethod
+    def _validate_hex_address(cls, value: str) -> str:
+        if set(value) > set("x0123456789abcdefABCDEF") or len(value) % 2 != 0:
             raise ValueError("Address is not hex")
 
-        address_bytes = bytes.fromhex(v[2:])  # NOTE: Skip `0x`
-
+        address_bytes = bytes.fromhex(value[2:])  # NOTE: Skip `0x`
         if len(address_bytes) != 20:
             raise ValueError("Address is incorrect length")
 
-        return v
+        return value
+
+    @classmethod
+    def _is_base58_address(cls, value: str) -> bool:
+        if not value or set(value) - BASE58_CHARACTERS:
+            return False
+
+        decoded_length = len(cls._decode_base58(value))
+        return 1 <= decoded_length <= 64
+
+    @classmethod
+    def _decode_base58(cls, value: str) -> bytes:
+        integer = 0
+        for character in value:
+            integer = integer * 58 + BASE58_ALPHABET.index(character)
+
+        decoded = bytearray()
+        while integer > 0:
+            integer, remainder = divmod(integer, 256)
+            decoded.append(remainder)
+
+        decoded.reverse()
+        leading_zeroes = len(value) - len(value.lstrip("1"))
+        return (b"\x00" * leading_zeroes) + bytes(decoded)
 
     @field_validator("decimals")
     def decimals_must_be_uint8(cls, v: TokenDecimals):


### PR DESCRIPTION
### What I did

This PR implements several UX/DX enhancements that should improve usability of this library. They are:

- Search for symbol in all tokenlists from cache (in an optional sorted order), instead of just a default
- Make sure chain-agnostic by default
- Move to python standard entrypoint so that `uv tool`/`uvx` works without additional changes
- Store installation URL and add `tokenlists update` subcommand to update them to lastest version
- Add `tokenlists suggestions` to suggest lists to install
- Support Solana Base58 addresses (now used by Uniswap Labs Default list)
- Refactor to (async-capable) `httpx` from `requests`, and support http proxies for installation

fixes: #28
fixes: #31 

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss any methods that should be used to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
- [x] New test cases have been added
- [x] Documentation has been updated
